### PR TITLE
Powerset construction: From NFA to DFA

### DIFF
--- a/FormalSystems/Chomsky/Regular/PowersetConstruction.lean
+++ b/FormalSystems/Chomsky/Regular/PowersetConstruction.lean
@@ -14,16 +14,6 @@ def DFA.fromNFA (M: NFA α qs): DFA α (Finset M.Q) where
 
 variable [DecidableEq α] [DecidableEq qs] { M: NFA α qs }
 
-theorem fold_union_subs [DecidableEq β] { f: α → Finset β } { qa qb: Finset α } (h: qa ⊆ qb):
-  Finset.fold (β:=Finset β) (· ∪ ·) ∅ f qa ⊆ Finset.fold (· ∪ ·) ∅ f qb := by
-  apply Finset.subset_iff.mpr
-  intro _ h
-  apply Finset.mem_fold_union_iff.mpr
-  have ⟨x, _, _⟩ := Finset.mem_fold_union_iff.mp h
-  exists x; constructor
-  apply Finset.mem_of_subset
-  repeat { assumption }
-
 def DFA.fromNFA.RunFromRestricted { qs: _ }
   (r: (DFA.fromNFA M).Run q w)
   (h: q.val ⊆ qs.val):
@@ -39,7 +29,7 @@ def DFA.fromNFA.RunFromRestricted { qs: _ }
     assumption
     dsimp [toNFA, fromNFA] at x; simp at x
     simp_rw [x]
-    apply fold_union_subs
+    apply Finset.fold_union_subs
     repeat { assumption }
 
 theorem DFA.fromNFA.RunFromRestricted_final

--- a/FormalSystems/Chomsky/Regular/PowersetConstruction.lean
+++ b/FormalSystems/Chomsky/Regular/PowersetConstruction.lean
@@ -1,0 +1,143 @@
+import FormalSystems.Chomsky.Regular.DFA
+
+variable [DecidableEq α] [DecidableEq qs] 
+
+def DFA.fromNFA (M: NFA α qs): DFA α (Finset M.Q) where
+  Z := M.Z
+  Q := Finset.univ
+  q₀ := ⟨ M.Q₀, Fintype.complete _ ⟩
+  F := Finset.univ.filter (λs => ∃q ∈ s.val, q ∈ M.F)
+
+  δ := fun (q, a) => .some $
+    ⟨ Finset.fold (β:=Finset M.Q) (· ∪ ·) ∅ (λq => M.δ (q, a)) q, by simp ⟩
+
+variable [DecidableEq α] [DecidableEq qs] { M: NFA α qs }
+
+theorem mem_fold_union_iff [DecidableEq β] { f: α → Finset β }:
+  (∃ x ∈ s, e ∈ f x) ↔ e ∈ Finset.fold Union.union ∅ f s := by
+  constructor
+  . intro ⟨x, h₁, h₂⟩
+    have ⟨s, _⟩ := s
+    revert s
+    apply Quot.ind
+    intro l _ h
+    simp [Finset.fold, Multiset.fold]
+    induction l with
+    | nil => contradiction
+    | cons _ _ ih =>
+      cases h
+      . simp; apply Or.inl
+        assumption
+      . simp; apply Or.inr
+        apply ih
+        assumption
+        apply And.right ∘ Multiset.nodup_cons.mp
+        assumption
+  
+  . cases s
+    case mk s' _ =>
+      revert s'
+      apply Quot.ind
+      intro l _ h
+      simp [Finset.fold] at h
+      induction l with
+      | nil => contradiction
+      | cons x _ ih => 
+        simp at h
+        cases h
+        exists x; simp; assumption
+        have := ih (by apply And.right ∘ Multiset.nodup_cons.mp; assumption)
+        have ⟨x, _, _⟩ := this (by assumption)
+        exists x
+        constructor
+        simp; apply Or.inr; assumption
+        assumption
+
+theorem fold_union_subs [DecidableEq β] { f: α → Finset β } { qa qb: Finset α } (h: qa ⊆ qb):
+  Finset.fold (β:=Finset β) (· ∪ ·) ∅ f qa ⊆ Finset.fold (· ∪ ·) ∅ f qb := by
+  apply Finset.subset_iff.mpr
+  intro _ h
+  apply mem_fold_union_iff.mp
+  have ⟨x, _, _⟩ := mem_fold_union_iff.mpr h
+  exists x; constructor
+  apply Finset.mem_of_subset
+  repeat { assumption }
+
+def DFA.fromNFA.RunFromRestricted { qs: _ }
+  (r: (DFA.fromNFA M).Run q w)
+  (h: q.val ⊆ qs.val):
+  (DFA.fromNFA M).Run qs w := by
+  cases r
+  apply NFA.Run.final
+  assumption
+  case step x _ =>
+    apply NFA.Run.step
+    dsimp [toNFA, fromNFA]; simp
+    rfl
+    apply RunFromRestricted
+    assumption
+    dsimp [toNFA, fromNFA] at x; simp at x
+    simp_rw [x]
+    apply fold_union_subs
+    repeat { assumption }
+
+theorem DFA.fromNFA.RunFromRestricted_final
+  (h: r.last ∈ (DFA.fromNFA M).F):
+  (DFA.fromNFA.RunFromRestricted r h').last ∈ (DFA.fromNFA M).F := by
+  cases r
+  . dsimp [NFA.Run.last, fromNFA] at h
+    rw [Finset.mem_filter] at h
+    dsimp [RunFromRestricted, NFA.Run.last, fromNFA]
+    rw [Finset.mem_filter]
+    constructor
+    rw [Finset.attach_eq_univ]; dsimp [Finset.univ]
+    apply Fintype.complete
+    have ⟨_, q, _, _⟩ := h
+    exists q; constructor
+    apply Finset.mem_of_subset
+    repeat { assumption }
+  . dsimp [RunFromRestricted, NFA.Run.last]
+    apply RunFromRestricted_final
+    dsimp [NFA.Run.last] at h
+    assumption
+
+def DFA.fromNFA.NFARunToRun (r: M.Run q w):
+  (DFA.fromNFA M).Run ⟨{q}, Fintype.complete _⟩ w := by
+  cases r
+  apply NFA.Run.final
+  assumption
+  apply NFA.Run.step
+  dsimp [fromNFA, toNFA]; simp
+  rfl
+  apply RunFromRestricted
+  apply NFARunToRun
+  repeat { simp; assumption }
+
+theorem DFA.fromNFA.NFARunToRun_final_imp_final { r: M.Run q w} (h: r.last ∈ M.F):
+  (NFARunToRun r).last ∈ (DFA.fromNFA M).F := by
+  cases r
+  . dsimp [NFA.Run.last, fromNFA]
+    rw [Finset.mem_filter]; constructor
+    rw [Finset.attach_eq_univ]; dsimp [Finset.univ]
+    apply Fintype.complete
+    exists q; simp
+    dsimp [NFA.Run.last] at h
+    assumption
+  
+  . dsimp [NFARunToRun, NFA.Run.last]
+    apply RunFromRestricted_final
+    apply NFARunToRun_final_imp_final
+    dsimp [NFA.Run.last] at h
+    assumption
+
+theorem NFA.lang_subs_DFA_fromNFA_lang:
+  M.GeneratedLanguage ⊆ (DFA.fromNFA M).GeneratedLanguage := by
+  intro w ⟨_, h_start, run, h_run⟩
+  constructor; swap
+  apply DFA.fromNFA.RunFromRestricted
+  apply DFA.fromNFA.NFARunToRun
+  assumption
+  simp [DFA.fromNFA]; assumption
+  apply DFA.fromNFA.RunFromRestricted_final
+  apply DFA.fromNFA.NFARunToRun_final_imp_final
+  assumption

--- a/FormalSystems/Chomsky/Regular/PowersetConstruction.lean
+++ b/FormalSystems/Chomsky/Regular/PowersetConstruction.lean
@@ -1,4 +1,5 @@
 import FormalSystems.Chomsky.Regular.DFA
+import FormalSystems.Preliminaries.Fold
 
 variable [DecidableEq α] [DecidableEq qs] 
 
@@ -13,52 +14,12 @@ def DFA.fromNFA (M: NFA α qs): DFA α (Finset M.Q) where
 
 variable [DecidableEq α] [DecidableEq qs] { M: NFA α qs }
 
-theorem mem_fold_union_iff [DecidableEq β] { f: α → Finset β }:
-  (∃ x ∈ s, e ∈ f x) ↔ e ∈ Finset.fold Union.union ∅ f s := by
-  constructor
-  . intro ⟨x, h₁, h₂⟩
-    have ⟨s, _⟩ := s
-    revert s
-    apply Quot.ind
-    intro l _ h
-    simp [Finset.fold, Multiset.fold]
-    induction l with
-    | nil => contradiction
-    | cons _ _ ih =>
-      cases h
-      . simp; apply Or.inl
-        assumption
-      . simp; apply Or.inr
-        apply ih
-        assumption
-        apply And.right ∘ Multiset.nodup_cons.mp
-        assumption
-  
-  . cases s
-    case mk s' _ =>
-      revert s'
-      apply Quot.ind
-      intro l _ h
-      simp [Finset.fold] at h
-      induction l with
-      | nil => contradiction
-      | cons x _ ih => 
-        simp at h
-        cases h
-        exists x; simp; assumption
-        have := ih (by apply And.right ∘ Multiset.nodup_cons.mp; assumption)
-        have ⟨x, _, _⟩ := this (by assumption)
-        exists x
-        constructor
-        simp; apply Or.inr; assumption
-        assumption
-
 theorem fold_union_subs [DecidableEq β] { f: α → Finset β } { qa qb: Finset α } (h: qa ⊆ qb):
   Finset.fold (β:=Finset β) (· ∪ ·) ∅ f qa ⊆ Finset.fold (· ∪ ·) ∅ f qb := by
   apply Finset.subset_iff.mpr
   intro _ h
-  apply mem_fold_union_iff.mp
-  have ⟨x, _, _⟩ := mem_fold_union_iff.mpr h
+  apply Finset.mem_fold_union_iff.mpr
+  have ⟨x, _, _⟩ := Finset.mem_fold_union_iff.mp h
   exists x; constructor
   apply Finset.mem_of_subset
   repeat { assumption }

--- a/FormalSystems/Chomsky/Regular/PowersetConstruction.lean
+++ b/FormalSystems/Chomsky/Regular/PowersetConstruction.lean
@@ -102,3 +102,43 @@ theorem NFA.lang_subs_DFA_fromNFA_lang:
   apply DFA.fromNFA.RunFromRestricted_final
   apply DFA.fromNFA.NFARunToRun_final_imp_final
   assumption
+
+theorem DFA.fromNFA_run_imp_run
+  { q₀: (DFA.fromNFA M).Q }
+  { r: (DFA.fromNFA M).Run q₀ w } (h: r.last ∈ (DFA.fromNFA M).F):
+  ∃q ∈ q₀.val, ∃r': M.Run q w, r'.last ∈ M.F := by
+  match r with
+  | .final _ _ =>
+    dsimp [NFA.Run.last, fromNFA] at h
+    have ⟨_, qf, _, _⟩ := Finset.mem_filter.mp h
+    exists qf; constructor; assumption
+    apply Exists.intro; swap
+    apply NFA.Run.final _
+    assumption
+    dsimp [NFA.Run.last]
+    assumption
+  | .step _ h_step _ _ =>
+    dsimp [NFA.Run.last] at h
+    dsimp [fromNFA, toNFA] at h_step; simp at h_step
+    have ⟨_, h_q₂, r', hr'⟩ := fromNFA_run_imp_run h
+    rw [h_step, Finset.mem_fold_union_iff] at h_q₂
+    have ⟨x, _, _⟩ := h_q₂
+    exists x; constructor; assumption
+    apply Exists.intro; swap
+    apply NFA.Run.step
+    repeat { assumption }
+
+theorem NFA.DFA_fromNFA_lang_subs_lang:
+  (DFA.fromNFA M).GeneratedLanguage ⊆ M.GeneratedLanguage := by
+  intro w ⟨_, hr⟩
+  have ⟨q, hq, r, _⟩ := DFA.fromNFA_run_imp_run hr
+  exists q
+  dsimp [DFA.fromNFA] at hq
+  constructor; assumption
+  exists r
+
+theorem NFA.fromNFA_lang_eq_lang:
+  (DFA.fromNFA M).GeneratedLanguage = M.GeneratedLanguage := by
+  apply Set.ext; intros; constructor
+  apply DFA_fromNFA_lang_subs_lang
+  apply lang_subs_DFA_fromNFA_lang

--- a/FormalSystems/Preliminaries/Fold.lean
+++ b/FormalSystems/Preliminaries/Fold.lean
@@ -35,19 +35,16 @@ theorem List.mem_fold_union_iff { l: List (Finset β) }:
 theorem Finset.mem_fold_union_iff { f: α → Finset β }:
   e ∈ Finset.fold Union.union ∅ f s ↔ ∃ x ∈ s, e ∈ f x := by
   constructor
-  . cases s
-    case mk s' _ =>
-      revert s'
-      apply Quot.ind
-      intro l _ h
-      simp [Finset.fold] at h
-      have ⟨_, h, _⟩ := List.mem_fold_union_iff.mp h
-      simp at h
-      have ⟨x, _, h⟩ := h
-      exists x; simp
-      constructor
-      assumption
-      rw [h]; assumption
+  . have ⟨s, _⟩ := s
+    revert s
+    apply Quot.ind
+    intro l _ h
+    dsimp [Finset.fold] at h
+    have ⟨_, h, _⟩ := List.mem_fold_union_iff.mp h
+    simp at h
+    have ⟨x, _, h⟩ := h
+    exists x; simp [h]
+    constructor; repeat { assumption }
 
   . intro ⟨x, h₁, h₂⟩
     have ⟨s, _⟩ := s

--- a/FormalSystems/Preliminaries/Fold.lean
+++ b/FormalSystems/Preliminaries/Fold.lean
@@ -57,3 +57,13 @@ theorem Finset.mem_fold_union_iff { f: α → Finset β }:
     simp; constructor
     exists x
     assumption
+
+theorem Finset.fold_union_subs [DecidableEq β] { f: α → Finset β } { qa qb: Finset α } (h: qa ⊆ qb):
+  Finset.fold (β:=Finset β) (· ∪ ·) ∅ f qa ⊆ Finset.fold (· ∪ ·) ∅ f qb := by
+  apply Finset.subset_iff.mpr
+  intro _ h
+  apply Finset.mem_fold_union_iff.mpr
+  have ⟨x, _, _⟩ := Finset.mem_fold_union_iff.mp h
+  exists x; constructor
+  apply Finset.mem_of_subset
+  repeat { assumption }

--- a/FormalSystems/Preliminaries/Fold.lean
+++ b/FormalSystems/Preliminaries/Fold.lean
@@ -1,0 +1,62 @@
+import Mathlib.Data.List.Basic
+import Mathlib.Data.Finset.Fold
+
+variable [DecidableEq β]
+
+theorem List.mem_fold_union_iff { l: List (Finset β) }:
+  e ∈ List.foldr (· ∪ ·) ∅ l ↔ ∃s ∈ l, e ∈ s := by
+  constructor
+  . intro h
+    induction l with
+    | nil => contradiction
+    | cons _ _ ih =>
+      simp at h
+      cases h <;> simp
+      . apply Or.inl
+        assumption
+      . apply Or.inr
+        apply ih
+        assumption
+
+  . intro ⟨s, h, _⟩
+    induction l with
+    | nil => contradiction
+    | cons _ _ ih =>
+      simp at h
+      cases h <;> simp
+      case inl h =>
+        apply Or.inl; rw [<- h]
+        assumption
+      case inr _ =>
+        apply Or.inr
+        apply ih
+        assumption
+
+theorem Finset.mem_fold_union_iff { f: α → Finset β }:
+  e ∈ Finset.fold Union.union ∅ f s ↔ ∃ x ∈ s, e ∈ f x := by
+  constructor
+  . cases s
+    case mk s' _ =>
+      revert s'
+      apply Quot.ind
+      intro l _ h
+      simp [Finset.fold] at h
+      have ⟨_, h, _⟩ := List.mem_fold_union_iff.mp h
+      simp at h
+      have ⟨x, _, h⟩ := h
+      exists x; simp
+      constructor
+      assumption
+      rw [h]; assumption
+
+  . intro ⟨x, h₁, h₂⟩
+    have ⟨s, _⟩ := s
+    revert s
+    apply Quot.ind
+    intro l _ h
+    simp [Finset.fold, Multiset.fold]
+    apply List.mem_fold_union_iff.mpr
+    exists f x
+    simp; constructor
+    exists x
+    assumption


### PR DESCRIPTION
One notable difference to the other constructions is that the conversion `(DFA.fromNFA M).Run -> M.Run` is a theorem and thus does not generate any program code. I did this because in this case there is no "canonical" conversion, since there could be more than one possible NFA-run, but they all correspond to the same run in the deterministic powerset machine, thus there would be some choice in the conversion.

Actually I don't know if there is even a "computable" way to specify this conversion in general, because Finsets in Lean are internally defined by quotients, so there is no deterministic notion of iterating through the elements of a Finset. So I believe if one wanted to have this conversion done computably, one would also need to assume an order on the set of state or similar, to make it deterministic.