### PR TITLE
Use elan for CI without nix

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,14 +4,29 @@ on:
       - main
 
 jobs:
-  build-with-nix:
+  build-with-elan:
     runs-on: ubuntu-latest
     steps:
+      - name: install elan
+        run: |
+          set -o pipefail
+          curl -sSfL https://github.com/leanprover/elan/releases/download/v3.0.0/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          ./elan-init -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v7
-      - uses: DeterminateSystems/magic-nix-cache-action@v2
-      - uses: cachix/cachix-action@v12
-        with:
-          name: lean4
-          skipPush: true
-      - run: nix build
+
+      - name: build project
+        run: lake build
+
+  # build-with-nix:
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: DeterminateSystems/nix-installer-action@v7
+  #     - uses: DeterminateSystems/magic-nix-cache-action@v2
+  #     - uses: cachix/cachix-action@v12
+  #       with:
+  #         name: lean4
+  #         skipPush: true
+  #     - run: nix build
+

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,14 +19,16 @@ jobs:
       - name: build project
         run: lake build
 
-  # build-with-nix:
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: DeterminateSystems/nix-installer-action@v7
-  #     - uses: DeterminateSystems/magic-nix-cache-action@v2
-  #     - uses: cachix/cachix-action@v12
-  #       with:
-  #         name: lean4
-  #         skipPush: true
-  #     - run: nix build
+  build-with-nix:
+    runs-on: ubuntu-latest
+    if: ${{ false }} # nix is currently broken, see #18
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v7
+      - uses: DeterminateSystems/magic-nix-cache-action@v2
+      - uses: cachix/cachix-action@v12
+        with:
+          name: lean4
+          skipPush: true
+      - run: nix build
 


### PR DESCRIPTION
Since the nix build does not seem to be so easy to fix as of now, we can instead use elan in the CI to verify that `lake build` works.